### PR TITLE
Dev 0.30.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Usage:
       local-domains
       strong-domains
 
+      Alternatives
+      ------------
+      no-expand
+      columns-as-domains
+
       Explore Results
       ---------------
       export
@@ -201,6 +206,35 @@ strong-domains
   --threads=<int> [default: 6]
   --verbose=<boolean> [default: true]
   --strongdomains=<file> [default: 'strong-domains.txt.gz']
+```
+
+
+#### Alternatives
+
+**No expansion:** Use the `no-expand` option when discovering local domains on the original dataset columns (without expansion). This option will output a columns file in the same format as the `expand-columns` step that can be used as input for the `local-domains` step.
+
+```
+$> java -jar /home/user/lib/D4.jar no-expand --help
+D4 - Data-Driven Domain Discovery - Version (0.30.1)
+
+no-expand
+  --eqs=<file> [default: 'compressed-term-index.txt.gz']
+  --verbose=<boolean> [default: true]
+  --columns=<file> [default: 'expanded-columns.txt.gz']
+```
+
+
+**Whole column as domain:** Instead of discovering local domains within (expanded) columns there is now an option to treat each unique (expanded) column as a local domain.
+
+```
+$> java -jar /home/user/lib/D4.jar columns-as-domains --help
+D4 - Data-Driven Domain Discovery - Version (0.30.1)
+
+columns-as-domains
+  --eqs=<file> [default: 'compressed-term-index.txt.gz']
+  --columns=<file> [default: 'expanded-columns.txt.gz']
+  --verbose=<boolean> [default: true]
+  --localdomains=<file> [default: 'local-domains.txt.gz']
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,11 @@
                    <archive>
                       <manifest>
                             <addClasspath>true</addClasspath>
-                            <!--mainClass>org.opendata.curation.d4.D4</mainClass-->
+                            <mainClass>org.opendata.curation.d4.D4</mainClass>
                             <!--mainClass>org.opendata.curation.d4.signature.RobustSignatureGenerator</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.domain.DomainSetStatsPrinter</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.evaluate.BestGTLocalMatchPrinter</mainClass-->
-                            <mainClass>org.opendata.curation.d4.evaluate.BestGTLocalMatchWriter</mainClass>
+                            <!--mainClass>org.opendata.curation.d4.evaluate.BestGTLocalMatchWriter</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.evaluate.PrepareGTFile</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.export.ExportStrongDomains</mainClass-->
                             <!--mainClass>org.opendata.db.eq.SimilarTermIndexGenerator</mainClass-->

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                       <manifest>
                             <addClasspath>true</addClasspath>
                             <mainClass>org.opendata.curation.d4.D4</mainClass>
+                            <!--mainClass>org.opendata.curation.d4.D4Interactive</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.signature.RobustSignatureGenerator</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.domain.DomainSetStatsPrinter</mainClass-->
                             <!--mainClass>org.opendata.curation.d4.evaluate.BestGTLocalMatchPrinter</mainClass-->

--- a/src/main/java/org/opendata/core/graph/UndirectedConnectedComponents.java
+++ b/src/main/java/org/opendata/core/graph/UndirectedConnectedComponents.java
@@ -17,6 +17,7 @@
  */
 package org.opendata.core.graph;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +77,7 @@ public class UndirectedConnectedComponents implements ConnectedComponentGenerato
         }
     }
     
+    @Override
     public synchronized void edge(int sourceId, int targetId) {	
         
         int sourceCompId = _componentMap[sourceId];

--- a/src/main/java/org/opendata/core/set/IDSet.java
+++ b/src/main/java/org/opendata/core/set/IDSet.java
@@ -17,6 +17,7 @@
  */
 package org.opendata.core.set;
 
+import com.google.gson.JsonArray;
 import java.math.BigDecimal;
 import java.util.List;
 import org.opendata.core.object.ObjectFilter;
@@ -44,4 +45,5 @@ public interface IDSet extends ObjectSet<Integer>, ObjectFilter<Integer> {
     public List<Integer> toSortedList();
     public IDSet union(IDSet list);
     public IDSet union(int id);
+    public JsonArray toJsonArray();
 }

--- a/src/main/java/org/opendata/core/set/IDSetImpl.java
+++ b/src/main/java/org/opendata/core/set/IDSetImpl.java
@@ -17,6 +17,8 @@
  */
 package org.opendata.core.set;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
@@ -210,6 +212,18 @@ public abstract class IDSetImpl extends ObjectSetImpl<Integer> implements IDSet 
     
         List<Integer> result = this.toList();
         Collections.sort(result);
+        return result;
+    }
+
+    @Override
+    public JsonArray toJsonArray() {
+        
+        JsonArray result = new JsonArray();
+        
+        for (int eqId : this.toArray()) {
+            result.add(new JsonPrimitive(eqId));
+        }
+        
         return result;
     }
     

--- a/src/main/java/org/opendata/core/set/IdentifiableIDSetWrapper.java
+++ b/src/main/java/org/opendata/core/set/IdentifiableIDSetWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.opendata.core.set;
 
+import com.google.gson.JsonArray;
 import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
@@ -179,6 +180,12 @@ public class IdentifiableIDSetWrapper extends IdentifiableObjectImpl implements 
     public String toIntString() {
 
         return _values.toIntString();
+    }
+
+    @Override
+    public JsonArray toJsonArray() {
+
+        return _values.toJsonArray();
     }
 
     @Override

--- a/src/main/java/org/opendata/curation/d4/Constants.java
+++ b/src/main/java/org/opendata/curation/d4/Constants.java
@@ -26,5 +26,5 @@ public final class Constants {
     
     public static final String NAME = "D4 - Data-Driven Domain Discovery";
     
-    public static final String VERSION = "0.30.1.dev01";
+    public static final String VERSION = "0.30.1";
 }

--- a/src/main/java/org/opendata/curation/d4/Constants.java
+++ b/src/main/java/org/opendata/curation/d4/Constants.java
@@ -26,5 +26,5 @@ public final class Constants {
     
     public static final String NAME = "D4 - Data-Driven Domain Discovery";
     
-    public static final String VERSION = "0.30.1";
+    public static final String VERSION = "0.30.1.dev03";
 }

--- a/src/main/java/org/opendata/curation/d4/Constants.java
+++ b/src/main/java/org/opendata/curation/d4/Constants.java
@@ -26,5 +26,5 @@ public final class Constants {
     
     public static final String NAME = "D4 - Data-Driven Domain Discovery";
     
-    public static final String VERSION = "0.30.0";
+    public static final String VERSION = "0.30.1.dev01";
 }

--- a/src/main/java/org/opendata/curation/d4/Constants.java
+++ b/src/main/java/org/opendata/curation/d4/Constants.java
@@ -26,5 +26,5 @@ public final class Constants {
     
     public static final String NAME = "D4 - Data-Driven Domain Discovery";
     
-    public static final String VERSION = "0.30.1.dev03";
+    public static final String VERSION = "0.30.1";
 }

--- a/src/main/java/org/opendata/curation/d4/D4.java
+++ b/src/main/java/org/opendata/curation/d4/D4.java
@@ -94,6 +94,43 @@ public class D4 {
                     .run(files, threads);
         }
     }
+    
+    public void columnsAsDomains(
+            File eqFile,
+            File columnsFile,
+            boolean verbose,
+            File outputFile
+    ) throws java.io.IOException {
+
+        if (verbose) {
+            System.out.println(
+                    String.format(
+                            "%s\n" +
+                            "  --columns=%s\n" +
+                            "  --localdomains=%s",
+                            STEP_COLUMN_DOMAINS,
+                            columnsFile.getAbsolutePath(),
+                            outputFile.getAbsolutePath()
+                    )
+            );
+        }
+        
+        DataManager db = new DataManager(new CompressedTermIndexFile(eqFile));
+
+        ExpandedColumnIndex columnIndex = new ExpandedColumnIndex();
+        new ExpandedColumnReader(columnsFile).stream(columnIndex);
+        
+        new InMemLocalDomainGenerator().columnsAsDomains(
+            columnIndex,
+            new DomainWriter(outputFile)
+        );
+        
+        if (verbose) {
+            DomainSetStatsPrinter localStats = new DomainSetStatsPrinter();
+            new DomainReader(outputFile).stream(localStats);
+            localStats.print();
+        }
+    }
 
     public void eqs(
             File inputFile,
@@ -580,7 +617,7 @@ public class D4 {
                         outputDir
                 );
             } catch (java.lang.InterruptedException | java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "COLUMN FILES", ex);
+                LOGGER.log(Level.SEVERE, STEP_GENERATE_COLUMNS, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_TERMINDEX)) {
@@ -620,7 +657,7 @@ public class D4 {
                         outputFile
                 );
             } catch (java.lang.InterruptedException | java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "TERM INDEX", ex);
+                LOGGER.log(Level.SEVERE, STEP_TERMINDEX, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_COMPRESS_TERMINDEX)) {
@@ -648,7 +685,7 @@ public class D4 {
                         outputFile
                 );
             } catch (java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "EQUIVALENCE CLASSES", ex);
+                LOGGER.log(Level.SEVERE, STEP_COMPRESS_TERMINDEX, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_SIGNATURES)) {
@@ -695,7 +732,7 @@ public class D4 {
                         signatureFile
                 );
             } catch (java.lang.InterruptedException | java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "SIGNATURES", ex);
+                LOGGER.log(Level.SEVERE, STEP_SIGNATURES, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_EXPAND_COLUMNS)) {
@@ -746,7 +783,7 @@ public class D4 {
                         columnsFile
                 );
             } catch (java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "EXPAND COLUMNS", ex);
+                LOGGER.log(Level.SEVERE, STEP_EXPAND_COLUMNS, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_LOCAL_DOMAINS)) {
@@ -799,7 +836,7 @@ public class D4 {
                         localDomainFile
                 );
             } catch (java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "LOCAL DOMAINS", ex);
+                LOGGER.log(Level.SEVERE, STEP_LOCAL_DOMAINS, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_STRONG_DOMAINS)) {
@@ -850,7 +887,7 @@ public class D4 {
                         strongDomainFile
                 );
             } catch (java.lang.InterruptedException | java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "STRONG DOMAINS", ex);
+                LOGGER.log(Level.SEVERE, STEP_STRONG_DOMAINS, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_NO_EXPAND)) {
@@ -878,7 +915,7 @@ public class D4 {
                         columnsFile
                 );
             } catch (java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "EXPORT DOMAINS", ex);
+                LOGGER.log(Level.SEVERE, STEP_NO_EXPAND, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_COLUMN_DOMAINS)) {
@@ -891,37 +928,28 @@ public class D4 {
                                 "eqs",
                                 "<file> [default: 'compressed-term-index.txt.gz']"
                         ),
-                        new Parameter("terms", "<file> [default: 'term-index.txt.gz']"),
-                        new Parameter("columns", "<file> [default: 'columns.tsv']"),
-                        new Parameter(
-                                "domains",
-                                "<file> [default: 'strong-domains.txt.gz']"
-                        ),
-                        new Parameter("sampleSize", "<int> [default: 100]"),
+                        new Parameter("columns", "<file> [default: 'expanded-columns.txt.gz']"),
                         new Parameter("verbose", "<boolean> [default: true]"),
-                        new Parameter("output", "<direcory> [default: 'domains']"),
+                        new Parameter(
+                                "localdomains",
+                                "<file> [default: 'local-domains.txt.gz']"
+                        )
                     },
                     args
             );
             File eqFile = params.getAsFile("eqs", "compressed-term-index.txt.gz");
-            File termFile = params.getAsFile("terms", "term-index.txt.gz");
-            File columnsFile = params.getAsFile("columns", "columns.tsv");
-            File domainsFile = params.getAsFile("domains", "strong-domains.txt.gz");
-            int samleSize = params.getAsInt("sampleSize", 100);
+            File columnsFile = params.getAsFile("columns", "expanded-columns.txt.gz");     
             boolean verbose = params.getAsBool("verbose", true);
-            File outputDir = params.getAsFile("output", "domains");
+            File localDomainFile = params.getAsFile("localdomains", "local-domains.txt.gz");
             try {
-                new D4().exportStrongDomains(
+                new D4().columnsAsDomains(
                         eqFile,
-                        termFile,
                         columnsFile,
-                        domainsFile,
-                        samleSize,
                         verbose,
-                        outputDir
+                        localDomainFile
                 );
             } catch (java.io.IOException ex) {
-                LOGGER.log(Level.SEVERE, "EXPORT DOMAINS", ex);
+                LOGGER.log(Level.SEVERE, STEP_COLUMN_DOMAINS, ex);
                 System.exit(-1);
             }
         } else if (command.equals(STEP_EXPORT_DOMAINS)) {

--- a/src/main/java/org/opendata/curation/d4/D4Interactive.java
+++ b/src/main/java/org/opendata/curation/d4/D4Interactive.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the Data-Driven Domain Discovery Tool (D4).
+ * 
+ * Copyright (c) 2018-2020 New York University.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendata.curation.d4;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import java.io.File;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.opendata.core.set.IdentifiableObjectSet;
+import org.opendata.curation.d4.column.ExpandedColumn;
+import org.opendata.curation.d4.column.ExpandedColumnReader;
+import org.opendata.curation.d4.domain.LocalDomainGenerator;
+import org.opendata.curation.d4.signature.SignatureBlocksIndex;
+import org.opendata.curation.d4.signature.SignatureBlocksReader;
+import org.opendata.db.Database;
+import org.opendata.db.eq.CompressedTermIndex;
+import org.opendata.db.eq.CompressedTermIndexFile;
+import org.opendata.db.term.TermIndexReader;
+
+/**
+ * Interactive D4.
+ * 
+ * @author @author Heiko Mueller <heiko.mueller@nyu.edu>
+ */
+public class D4Interactive {
+   
+    private final static String COMMAND =
+            "Usage:\n" +
+            "  <eq-file>\n" +
+            "  <term-file>\n" +
+            "  <signature-file>\n" +
+            "  <expanded-column-file>";
+    
+    private final static Logger LOGGER = Logger
+            .getLogger(D4Interactive.class.getName());
+    
+    public static void main(String[] args) throws java.io.IOException {
+        
+        System.out.println(Constants.NAME + " (Interactive) - Version (" + Constants.VERSION + ")\n");
+
+        if (args.length != 4) {
+            System.out.println(COMMAND);
+            System.exit(-1);
+        }
+        
+        File eqFile = new File(args[0]);
+        File termFile = new File(args[1]);
+        File signatureFile = new File(args[2]);
+        File columnsFile = new File(args[3]);
+        
+        CompressedTermIndex eqIndex = new CompressedTermIndexFile(eqFile);
+        TermIndexReader termIndex = new TermIndexReader(termFile);
+        
+        DataManager d4 = new DataManager(eqIndex);
+        Database db = new Database(eqIndex, termIndex);
+        
+        SignatureBlocksIndex signatures;
+        signatures = new SignatureBlocksReader(signatureFile).read();
+        
+        IdentifiableObjectSet<ExpandedColumn> columns;
+        columns = new ExpandedColumnReader(columnsFile).read();
+        
+        Scanner scanner = new Scanner(System.in);
+        while (true) {
+            System.out.print("D4 $> ");
+            String[] tokens = scanner.nextLine().split("\\s+");
+            if (tokens.length == 0) {
+                continue;
+            }
+            try {
+                switch (tokens[0]) {
+                    case "exit":
+                        System.out.println("See ya, mate!");
+                        return;
+                    case "local-domains":
+                        int columnId = Integer.parseInt(tokens[1]);
+                        String trimmer = D4Config.TRIMMER_CENTRIST;
+                        if (tokens.length >= 3) {
+                            trimmer = tokens[2].toUpperCase();
+                        }
+                        boolean originalOnly = false;
+                        if (tokens.length == 4) {
+                            originalOnly = Boolean.parseBoolean(tokens[3]);
+                        }
+                        LocalDomainGenerator domGen;
+                        domGen = new LocalDomainGenerator(signatures, d4.getEQTermCounts());
+                        JsonObject doc = domGen.getLocalDomain(
+                                columns.get(columnId),
+                                d4.getSignatureTrimmerFactory(trimmer, originalOnly)
+                        );
+                        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                        System.out.println(gson.toJson(doc));
+                        break;
+                    default:
+                        LOGGER.log(Level.INFO, String.format("Unknown command: %s", tokens[0]));
+                        break;
+                }
+            } catch (RuntimeException ex) {
+                LOGGER.log(Level.WARNING, tokens[0], ex);
+            }
+        }
+    }
+}

--- a/src/main/java/org/opendata/curation/d4/column/ExpandedColumnWriter.java
+++ b/src/main/java/org/opendata/curation/d4/column/ExpandedColumnWriter.java
@@ -41,6 +41,11 @@ public class ExpandedColumnWriter implements ExpandedColumnConsumer {
         _groups = groups;
     }
     
+    public ExpandedColumnWriter(File file) {
+        
+        this(file, new HashMap<>());
+    }
+    
     @Override
     public synchronized void close() {
 

--- a/src/main/java/org/opendata/curation/d4/column/ParallelColumnExpander.java
+++ b/src/main/java/org/opendata/curation/d4/column/ParallelColumnExpander.java
@@ -178,6 +178,18 @@ public class ParallelColumnExpander {
         this(new TelemetryPrinter());
     }
     
+    public void noExpand(IdentifiableObjectSet<Column> columns, File outputFile) {
+                
+        ExpandedColumnWriter writer;
+        writer = new ExpandedColumnWriter(outputFile);
+        
+        writer.open();
+        for (Column column : columns) {
+            writer.consume(new ImmutableExpandedColumn(column));
+        }
+        writer.close();
+    }
+
     public void run(
             Integer[] eqTermCounts,
             SignatureBlocksStream signatures,

--- a/src/main/java/org/opendata/curation/d4/domain/Domain.java
+++ b/src/main/java/org/opendata/curation/d4/domain/Domain.java
@@ -17,6 +17,8 @@
  */
 package org.opendata.curation.d4.domain;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
 import org.opendata.core.set.IDSet;
 import org.opendata.core.set.IdentifiableIDSet;
 import org.opendata.core.set.IdentifiableIDSetWrapper;

--- a/src/main/java/org/opendata/curation/d4/domain/InMemLocalDomainGenerator.java
+++ b/src/main/java/org/opendata/curation/d4/domain/InMemLocalDomainGenerator.java
@@ -31,7 +31,6 @@ import org.opendata.curation.d4.column.ExpandedColumn;
 import org.opendata.curation.d4.column.ExpandedColumnIndex;
 import org.opendata.curation.d4.signature.trim.SignatureTrimmer;
 import org.opendata.curation.d4.SignatureTrimmerFactory;
-import org.opendata.core.set.MutableIdentifiableIDSet;
 import org.opendata.core.util.MemUsagePrinter;
 import org.opendata.curation.d4.signature.RobustSignatureConsumer;
 import org.opendata.curation.d4.signature.SignatureBlocksStream;
@@ -119,6 +118,20 @@ public class InMemLocalDomainGenerator {
     public InMemLocalDomainGenerator() {
         
         this(new TelemetryPrinter());
+    }
+    
+    public void columnsAsDomains(
+            ExpandedColumnIndex columnIndex,
+            DomainConsumer consumer
+    ) throws java.io.IOException {
+
+        UniqueDomainSet domains = new UniqueDomainSet(columnIndex);
+        
+        for (ExpandedColumn column : columnIndex) {
+            domains.put(column.id(), column.nodes());
+        }
+        
+        domains.stream(consumer);
     }
     
     public void run(

--- a/src/main/java/org/opendata/curation/d4/domain/LocalDomainGenerator.java
+++ b/src/main/java/org/opendata/curation/d4/domain/LocalDomainGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the Data-Driven Domain Discovery Tool (D4).
+ * 
+ * Copyright (c) 2018-2020 New York University.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opendata.curation.d4.domain;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.util.Date;
+import org.opendata.curation.d4.SignatureTrimmerFactory;
+import org.opendata.curation.d4.column.ExpandedColumn;
+import org.opendata.curation.d4.column.ExpandedColumnIndex;
+import org.opendata.curation.d4.signature.SignatureBlocksStream;
+import org.opendata.curation.d4.signature.trim.SignatureTrimmer;
+
+/**
+ * Generator for local domains in an expanded column.
+ * 
+ * @author @author Heiko Mueller <heiko.mueller@nyu.edu>
+ */
+public class LocalDomainGenerator {
+    
+    private final Integer[] _eqTermCounts;
+    private final SignatureBlocksStream _signatures;
+
+    public LocalDomainGenerator(SignatureBlocksStream signatures, Integer[] eqTermCounts) {
+        
+        _signatures = signatures;
+        _eqTermCounts = eqTermCounts;
+    }
+    
+    public JsonObject getLocalDomain(
+            ExpandedColumn column,
+            SignatureTrimmerFactory trimmerFactory
+    ) {
+        
+        UniqueDomainSet domains;
+        domains = new UniqueDomainSet(new ExpandedColumnIndex(column));
+        
+        UndirectedDomainGenerator domainGenerator;
+        domainGenerator = new UndirectedDomainGenerator(
+                column,
+                domains,
+                _eqTermCounts
+        );
+        SignatureTrimmer trimmer;
+        trimmer = trimmerFactory.getSignatureTrimmer(column, domainGenerator);
+        Date runStart = new Date();
+        _signatures.stream(trimmer);
+        Date runEnd = new Date();
+        
+        JsonObject doc = new JsonObject();
+        // Column.
+        JsonObject col = new JsonObject();
+        col.add("original", column.originalNodes().toJsonArray());
+        col.add("expansion", column.expandedNodes().toJsonArray());
+        doc.add("column", col);
+        // Domains
+        JsonArray arrDomains = new JsonArray();
+        for (Domain domain : domains.domains()) {
+            arrDomains.add(domain.toJsonArray());
+        }
+        doc.add("domains", arrDomains);
+        // Exec. Time
+        doc.add("execTime", new JsonPrimitive(runEnd.getTime() - runStart.getTime()));
+        return doc;
+    }
+}

--- a/src/main/java/org/opendata/curation/d4/signature/RobustSignature.java
+++ b/src/main/java/org/opendata/curation/d4/signature/RobustSignature.java
@@ -32,4 +32,19 @@ public abstract class RobustSignature extends IdentifiableObjectImpl implements 
         
         super(id);
     }
+    
+    @Override
+    public String toString() {
+        
+        StringBuilder buf = new StringBuilder().append(this.id()).append("\t");
+        boolean first = true;
+        for (int memberId : this) {
+            if (!first) {
+                buf.append(",");
+            }
+            buf.append(memberId);
+            first = false;
+        }
+        return buf.toString();
+    }
 }

--- a/src/main/java/org/opendata/curation/d4/signature/SignatureBlocksIndex.java
+++ b/src/main/java/org/opendata/curation/d4/signature/SignatureBlocksIndex.java
@@ -91,7 +91,7 @@ public class SignatureBlocksIndex implements SignatureBlocksStream, SignatureBlo
         
         for (Integer nodeId : _elements.keySet()) {
             IndexElement el = _elements.get(nodeId);
-            consumer.consume(0, el.sim(), el.blocks());
+            consumer.consume(nodeId, el.sim(), el.blocks());
         }
         consumer.close();
     }


### PR DESCRIPTION
This PR includes a bug fix when streaming robust signature blocks from an in-memory buffer. It also introduces two alternative workflow steps for D4:

**No expansion:** Use the `no-expand` option when discovering local domains on the original dataset columns (without expansion). This option will output a columns file in the same format as the `expand-columns` step that can be used as input for the `local-domains` step.

```
$> java -jar /home/user/lib/D4.jar no-expand --help
D4 - Data-Driven Domain Discovery - Version (0.30.1)

no-expand
  --eqs=<file> [default: 'compressed-term-index.txt.gz']
  --verbose=<boolean> [default: true]
  --columns=<file> [default: 'expanded-columns.txt.gz']
```


**Whole column as domain:** Instead of discovering local domains within (expanded) columns there is now an option to treat each unique (expanded) column as a local domain.

```
$> java -jar /home/user/lib/D4.jar columns-as-domains --help
D4 - Data-Driven Domain Discovery - Version (0.30.1)

columns-as-domains
  --eqs=<file> [default: 'compressed-term-index.txt.gz']
  --columns=<file> [default: 'expanded-columns.txt.gz']
  --verbose=<boolean> [default: true]
  --localdomains=<file> [default: 'local-domains.txt.gz']
```
